### PR TITLE
Update docker-compose.prod.yml to use pre-built image from GHCR

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   number-trainer-web:
-    build: .
+    image: ghcr.io/elisey/number_trainer:latest
     ports:
       - "8000:8000"
     environment:
@@ -32,7 +32,3 @@ services:
       - /tmp
       - /var/tmp
       - /home/appuser/.cache
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.number-trainer.rule=Host(`localhost`)"
-      - "traefik.http.services.number-trainer.loadbalancer.server.port=8000"


### PR DESCRIPTION
This PR updates the production Docker Compose file to pull the pre-built image from GitHub Container Registry instead of building locally. This improves deployment efficiency and ensures consistency.