### PR TITLE
Fix Docker publish workflow: add Task installation step

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,6 +63,11 @@ jobs:
     - name: Install dependencies
       run: uv sync --group dev
 
+    - name: Install Task
+      uses: arduino/setup-task@v1
+      with:
+        version: '3.x'
+
     - name: Build and test Docker image using integration tests
       run: |
         echo "Running Docker integration tests..."


### PR DESCRIPTION
## Summary
- Fixed the Docker publish workflow that was failing due to missing Task installation
- Added `arduino/setup-task@v1` action to install Task before running integration tests
- Resolves the CI pipeline error where `uv run task test-integration` failed with "No such file or directory"

## Test plan
- [x] Verify workflow syntax is correct
- [ ] Test that CI pipeline runs successfully with this change
- [ ] Confirm integration tests execute properly in GitHub Actions

## Changes
- Added Task installation step using `arduino/setup-task@v1` with version `3.x`
- Positioned the installation after dependency setup and before integration tests